### PR TITLE
Repeat if 429

### DIFF
--- a/lib/dropbox/client.rb
+++ b/lib/dropbox/client.rb
@@ -504,9 +504,10 @@ module Dropbox
 
           # retries left:sleep time in seconds -- 5:5, 4:20, 3:45, 2:80, 1:125
           sleep_time = ((6 - retries_left)**2) * 5
+          # Mostly so we can speed up tests
+          sleep_time = ENV['429_SLEEP'].to_f if ENV['429_SLEEP']
           sleep(sleep_time)
           retries_left -= 1
-          res
         end
 
         raise ApiError.new(resp) if resp.code != 200

--- a/lib/dropbox/client.rb
+++ b/lib/dropbox/client.rb
@@ -500,17 +500,15 @@ module Dropbox
 
         # 429 errors are transient errors that should be retried. More info on them here:
         # https://www.dropbox.com/developers/reference/data-ingress-guide
-        if resp.code == 429
-          retries_left = 5
-          while retries_left > 0 && resp.code == 429
-            # retries left:sleep time in seconds -- 7:5, 6:5, 5:5, 4:20, 3:45, 2:80, 1:125
-            sleep_time = retries_left >= 5 ? 5 : ((6 - retries_left)**2)*5
-            sleep(sleep_time)
-            resp = HTTP.auth('Bearer ' + @access_token)
-                     .headers(content_type: ('application/json' if data))
-                     .post(url, json: data)
-            retries_left -= 1
-          end
+        retries_left = 5
+        while resp.code == 429 && retries_left > 0
+          # retries left:sleep time in seconds -- 5:5, 4:20, 3:45, 2:80, 1:125
+          sleep_time = ((6 - retries_left)**2) * 5
+          sleep(sleep_time)
+          resp = HTTP.auth('Bearer ' + @access_token)
+                   .headers(content_type: ('application/json' if data))
+                   .post(url, json: data)
+          retries_left -= 1
         end
         raise ApiError.new(resp) if resp.code != 200
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -25,4 +25,52 @@ class DropboxClientTest < Minitest::Test
       dbx.revoke_token
     end
   end
+
+  def test_too_many_write_requests_errors
+    too_many_writes_response = {'status' => 429, 'body' => {
+    "error_summary": "too_many_write_operations/...",
+    "error": {
+               ".tag": "too_many_write_operations"
+             }
+    }.to_json}
+    success_response = stub('file')
+    stub_request(:post, url('files/delete'))
+      .to_return(too_many_writes_response,
+                 success_response)
+    dbx = Dropbox::Client.new('12345678' * 8)
+    response = dbx.delete('/testing123/foo83.txt')
+    assert_instance_of Dropbox::FileMetadata, response
+  end
+
+  def test_too_many_write_upload_requests_errors
+    too_many_writes_response = {'status' => 429, 'body' => {
+    "error_summary": "too_many_write_operations/...",
+    "error": {
+               ".tag": "too_many_write_operations"
+             }
+    }.to_json}
+    success_response = stub('file')
+    stub_request(:post, content_url('files/upload'))
+      .to_return(too_many_writes_response,
+                 success_response)
+    dbx = Dropbox::Client.new('12345678' * 8)
+    response = dbx.upload('/testing123/foo83.txt', 'some content')
+    assert_instance_of Dropbox::FileMetadata, response
+  end
+
+  def test_too_many_write_content_requests_errors
+    too_many_writes_response = {'status' => 429, 'body' => {
+    "error_summary": "too_many_write_operations/...",
+    "error": {
+               ".tag": "too_many_write_operations"
+             }
+    }.to_json}
+    success_response = stub('file_content')
+    stub_request(:get, content_url('files/download'))
+      .to_return(too_many_writes_response,
+                 success_response)
+    dbx = Dropbox::Client.new('12345678' * 8)
+    response = dbx.download('/testing123/foo83.txt')
+    assert_instance_of Dropbox::FileMetadata, response.first
+  end
 end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -27,49 +27,49 @@ class DropboxClientTest < Minitest::Test
   end
 
   def test_too_many_write_requests_errors
-    too_many_writes_response = {'status' => 429, 'body' => {
-    "error_summary": "too_many_write_operations/...",
-    "error": {
-               ".tag": "too_many_write_operations"
-             }
-    }.to_json}
     success_response = stub('file')
     stub_request(:post, url('files/delete'))
-      .to_return(too_many_writes_response,
+      .to_return(too_many_write_operations_error,
                  success_response)
     dbx = Dropbox::Client.new('12345678' * 8)
+    ENV['429_SLEEP'] = '0.1'
+
     response = dbx.delete('/testing123/foo83.txt')
     assert_instance_of Dropbox::FileMetadata, response
   end
 
   def test_too_many_write_upload_requests_errors
-    too_many_writes_response = {'status' => 429, 'body' => {
-    "error_summary": "too_many_write_operations/...",
-    "error": {
-               ".tag": "too_many_write_operations"
-             }
-    }.to_json}
     success_response = stub('file')
     stub_request(:post, content_url('files/upload'))
-      .to_return(too_many_writes_response,
+      .to_return(too_many_write_operations_error,
                  success_response)
     dbx = Dropbox::Client.new('12345678' * 8)
+    ENV['429_SLEEP'] = '0.1'
+
     response = dbx.upload('/testing123/foo83.txt', 'some content')
     assert_instance_of Dropbox::FileMetadata, response
   end
 
+  def test_too_many_write_upload_requests_errors_always_429
+    stub_request(:post, content_url('files/upload'))
+      .to_return(too_many_write_operations_error)
+    dbx = Dropbox::Client.new('12345678' * 8)
+    ENV['429_SLEEP'] = '0.1'
+
+    err = assert_raises(Dropbox::ApiError) do
+      dbx.upload('/testing123/foo83.txt', 'some content')
+    end
+    assert_equal 'too_many_write_operations/...', err.message
+  end
+
   def test_too_many_write_content_requests_errors
-    too_many_writes_response = {'status' => 429, 'body' => {
-    "error_summary": "too_many_write_operations/...",
-    "error": {
-               ".tag": "too_many_write_operations"
-             }
-    }.to_json}
     success_response = stub('file_content')
     stub_request(:get, content_url('files/download'))
-      .to_return(too_many_writes_response,
+      .to_return(too_many_write_operations_error,
                  success_response)
     dbx = Dropbox::Client.new('12345678' * 8)
+    ENV['429_SLEEP'] = '0.1'
+
     response = dbx.download('/testing123/foo83.txt')
     assert_instance_of Dropbox::FileMetadata, response.first
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,20 @@ Content-Type: application/json
   EOS
 end
 
+def too_many_write_operations_error
+  <<-EOS
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
+
+{
+    "error_summary": "too_many_write_operations/...",
+    "error": {
+        ".tag": "too_many_write_operations"
+    }
+}
+  EOS
+end
+
 def stub(name)
   File.new("test/stubs/#{name}.json")
 end


### PR DESCRIPTION
If the Dropbox API returns a 429 error code, then retry the request up to 5 times.